### PR TITLE
Fix for assertion tripping on 3 variadic args

### DIFF
--- a/Sources/LittleBlueTooth/Classes/Model/Loggable.swift
+++ b/Sources/LittleBlueTooth/Classes/Model/Loggable.swift
@@ -16,12 +16,12 @@ protocol Loggable {
 
 extension Loggable  {
     func log(_ message: StaticString, log: OSLog, type: OSLogType, arg: [CVarArg]) {
+        assert(arg.count <= 3)
         #if !TEST
         // https://stackoverflow.com/questions/50937765/why-does-wrapping-os-log-cause-doubles-to-not-be-logged-correctly/50942917#50942917
         guard isLogEnabled else {
             return
         }
-        assert(arg.count <= 2)
         switch arg.count {
         case 1:
             os_log(type, log: log, message, arg[0])

--- a/Sources/LittleBlueTooth/LittleBlueTooth.swift
+++ b/Sources/LittleBlueTooth/LittleBlueTooth.swift
@@ -188,7 +188,7 @@ public class LittleBlueTooth: Identifiable {
             configuration.centralManagerOptions?[CBCentralManagerOptionRestoreIdentifierKey] != nil) ||
             (configuration.restoreHandler != nil &&
                 configuration.centralManagerOptions?[CBCentralManagerOptionRestoreIdentifierKey] == nil) {
-            print("If you want to use state preservation/restoration you should probablu want to implement the `restoreHandler`")
+            print("If you want to use state preservation/restoration you should probably want to implement the `restoreHandler`")
         }
         attachSubscribers(with: configuration.restoreHandler)
         self.isLogEnabled = configuration.isLogEnabled

--- a/Tests/LittleBlueToothTests/UtilityTest.swift
+++ b/Tests/LittleBlueToothTests/UtilityTest.swift
@@ -9,6 +9,7 @@
 import XCTest
 import CoreBluetoothMock
 import Combine
+import os.log
 @testable import LittleBlueToothForTest
 
 class UtilityTest: LittleBlueToothTests {
@@ -150,6 +151,24 @@ class UtilityTest: LittleBlueToothTests {
         
         XCTAssert(event1.count == 2)
         XCTAssert(event1 == event2)
+    }
+    
+    // MARK: - Loggable
+
+    /// Note that the current implementation does not actually `throw` but rather uses `assert`.  Nevertheless
+    /// wrapping with `XCTAssertNoThrow` accomplishes the goal of verifying the function behaviour while adding
+    /// a tiny future proof should assert be replaced by a thrown Error.
+    func testLoggableShouldAccept3Args() {
+        
+        class MockLogger: Loggable {
+            var isLogEnabled = true
+            static var wasCalled = false
+        }
+        
+        XCTAssertNoThrow(
+            MockLogger().log("3 may pass", log: OSLog.LittleBT_Log_General, type: .info,
+                             arg: ["arg1", "arg2", "arg3"])
+        )
     }
 
 }

--- a/Tests/LittleBlueToothTests/UtilityTest.swift
+++ b/Tests/LittleBlueToothTests/UtilityTest.swift
@@ -162,7 +162,6 @@ class UtilityTest: LittleBlueToothTests {
         
         class MockLogger: Loggable {
             var isLogEnabled = true
-            static var wasCalled = false
         }
         
         XCTAssertNoThrow(


### PR DESCRIPTION
Fix for crash due to assertion when more than 2 variadic args are passed to Loggable.log().

This is where 3 args are used in `LittleBlueTooth` `private func restore` shown [here](https://github.com/DrAma999/LittleBlueTooth/blob/a974ee594593b317efd9bcd2525eef3c8fd828ed/Sources/LittleBlueTooth/LittleBlueTooth.swift#L886-L888).  

I added a test to `UtilityTest.swift` for it, so I moved the assertion out of the conditional compilation !TEST region so it applies under test. I think this still supports what I imagine the intent of `TEST` is, to avoid cluttering output under test.

An additional test for the failure condition (4+ args) is not possible without some brittle trickery, replacing `assert` behaviour, so skipped that and simply manually verified that 4 arg would trip the assert().

I tested the branch under near identical conditions to further verify the fix.