### PR TITLE
Publish CBCentralManager state changes

### DIFF
--- a/Sources/LittleBlueTooth/LittleBlueTooth.swift
+++ b/Sources/LittleBlueTooth/LittleBlueTooth.swift
@@ -68,6 +68,11 @@ public final class LittleBlueTooth: Identifiable, @unchecked Sendable {
         return self.centralProxy.connectionEventPublisher.share().eraseToAnyPublisher()
     }()
     
+    /// Publisher that streams CBCentralManager state changes
+    public var centralStatePublisher: AnyPublisher<BluetoothState, Never> {
+        centralProxy.centralStatePublisher.eraseToAnyPublisher()
+    }
+    
     /// Publish name and service changes
     public var changesStatePublisher: AnyPublisher<PeripheralChanges, Never> {
         _peripheralChangesPublisher.eraseToAnyPublisher()


### PR DESCRIPTION
Adds a centralStatePublisher property to expose Bluetooth state changes from the central manager.
Used to trigger reconnection attempts when user turns on BT while app running.
No tests added, essentially just exposing centralProxy.centralStatePublisher.